### PR TITLE
Export diff constants

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,6 @@
-module.exports = require('./javascript/diff_match_patch_uncompressed.js').diff_match_patch;
+var gdiff = require('./javascript/diff_match_patch_uncompressed.js');
+module.exports = gdiff.diff_match_patch;
+module.exports.DIFF_DELETE = gdiff.DIFF_DELETE;
+module.exports.DIFF_INSERT = gdiff.DIFF_INSERT;
+module.exports.DIFF_EQUAL = gdiff.DIFF_EQUAL;
+


### PR DESCRIPTION
The diff constants are not exported this forces you to use values: -1, 0, 1 rather than the named constants; DIFF_DELETE, DIFF_EQUAL, DIFF_INSERT

eg.

``` javascript
var gdiff = require('googlediff');
var text1 = 'lorem ipsum';
var text2 = 'lorem porem';

var diff = new gdiff();
var d = diff.diff_main(text1, text2);

for(i in d) {
  if (d[i][0] === -1) {
    // Handle deletion
  }
}
```
## Versus

``` javascript
var gdiff = require('googlediff');
var text1 = 'lorem ipsum';
var text2 = 'lorem porem';

var diff = new gdiff();
var d = diff.diff_main(text1, text2);

for(i in d) {
  if (d[i][0] === gdiff.DIFF_DELETE) {
    // Handle deletion
  }
}
```
