### PR TITLE
follow commonjs style

### DIFF
--- a/javascript/diff_match_patch_uncompressed.js
+++ b/javascript/diff_match_patch_uncompressed.js
@@ -2187,7 +2187,7 @@ diff_match_patch.patch_obj.prototype.toString = function() {
 // In a browser, 'this' will be 'window'.
 // Users of node.js should 'require' the uncompressed version since Google's
 // JS compiler may break the following exports for non-browser environments.
-this['diff_match_patch'] = diff_match_patch;
-this['DIFF_DELETE'] = DIFF_DELETE;
-this['DIFF_INSERT'] = DIFF_INSERT;
-this['DIFF_EQUAL'] = DIFF_EQUAL;
+exports.diff_match_patch = diff_match_patch;
+exports.DIFF_DELETE = DIFF_DELETE;
+exports.DIFF_INSERT = DIFF_INSERT;
+exports.DIFF_EQUAL = DIFF_EQUAL;


### PR DESCRIPTION
With the help of bundlers like browserify, we don't have to consider the difference among environments as long as we follow commonjs packaging system. Some bundlers like React Native Packager cannot export variables using `this`. We'd like this module to be available universally.
